### PR TITLE
SEO 1.3.2 — Add unique meta descriptions (150–160 chars) to all pages

### DIFF
--- a/awards/index.html
+++ b/awards/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Awards & Recognition"
-description: Honors and awards received by Abubakar Riaz throughout his career at Tkxel, Jazz Telecom, and Mobilink.
+description: "Recognition and honors earned by Abubakar Riaz throughout his career at Tkxel, Jazz Telecom, and Mobilink — from performance awards to appreciation letters."
 ---
 
 <div class="page-hero">

--- a/certifications/index.html
+++ b/certifications/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Azure & DevOps Certifications"
-description: Full certifications list of Abubakar Riaz — 40+ credentials grouped by role and skill area.
+description: "Browse 40+ professional certifications earned by Abubakar Riaz — Azure, DevOps, GitHub, Google, and HashiCorp credentials, grouped by role and skill area."
 ---
 
 <div class="page-hero">

--- a/certifications/yearly/index.html
+++ b/certifications/yearly/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Certifications by Year"
-description: Year-wise certifications timeline of Abubakar Riaz.
+description: "Chronological timeline of 40+ certifications earned by Abubakar Riaz from 2015 to present — Azure, DevOps, GitHub, Google Cloud, and HashiCorp credentials."
 ---
 
 <div class="page-hero">

--- a/education/index.html
+++ b/education/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Education & Academic Background"
-description: Academic background of Abubakar Riaz — Computer Science, Commerce, and foundational studies.
+description: "Academic background of Abubakar Riaz — BS Computer Science from Virtual University of Pakistan and BCom from Hailey College of Commerce, Lahore, Pakistan."
 ---
 
 <div class="page-hero">

--- a/experience/index.html
+++ b/experience/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "15+ Years Cloud & DevOps"
-description: Full professional experience of Abubakar Riaz — 15+ years across DevOps, cloud architecture, full-stack development, ETL, and telecom.
+description: "Explore 15+ years of career history by Abubakar Riaz — Jazz Telecom, Punjab Group, and Tkxel, spanning ETL, DevOps, .NET, and Azure cloud architecture."
 ---
 
 <div class="page-hero">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: "Associate Cloud Architect at Tkxel. Azure Solutions Architect Expert and Microsoft Certified Trainer with 15+ years in IT. Specializing in DevOps, CI/CD, and cloud architecture."
+description: "Abubakar Riaz — Associate Cloud Architect at Tkxel with 15+ years in cloud, DevOps, and .NET. Azure Solutions Architect Expert, MCT, Terraform Associate."
 ---
 
 <!-- ============================================================

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Cloud & DevOps Projects"
-description: Full portfolio of projects developed and maintained by Abubakar Riaz across 13+ years.
+description: "Discover 40+ enterprise cloud and DevOps projects by Abubakar Riaz — CI/CD pipelines, ETL systems, and cloud-native apps built with Azure, .NET, and Terraform."
 ---
 
 <div class="page-hero">


### PR DESCRIPTION
## What this PR does
Updates the `description` front matter on all 7 pages to unique, keyword-rich meta descriptions between 150–160 characters. The `{% seo %}` tag in `_layouts/default.html` already renders `<meta name="description">` — these updates ensure the content is optimized.

## Files changed
- `index.html` — new 153-char description (was 177, too long)
- `experience/index.html` — new 151-char description (was 134, too short)
- `certifications/index.html` — new 154-char description (was 91, too short)
- `projects/index.html` — new 159-char description (was 86, too short)
- `education/index.html` — new 154-char description (was 92, too short)
- `awards/index.html` — new 156-char description (was 103, too short)
- `certifications/yearly/index.html` — new 155-char description (was 51, too short)

## Acceptance criteria (from Notion WBS)
- [x] Every page has a unique `<meta name="description">` tag
- [x] Every description is between 150–160 characters

## How to verify
```bash
for url in "" "experience/" "certifications/" "projects/" "education/" "awards/" "certifications/yearly/"; do
  curl -s "https://abubakarriaz.com.pk/$url" | grep 'meta name="description"'
done
```
Each page should return a unique description. Length check: all are 151–159 chars.

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 2. SEO Hardening → 1.3.2