### PR TITLE
SEO 2.3.1 — Add BreadcrumbList JSON-LD to all inner pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,6 +76,18 @@
   }
   </script>
   {% endif %}
+  {% unless page.url == "/" %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "{{ site.url }}/" },
+      { "@type": "ListItem", "position": 2, "name": {{ page.title | jsonify }}, "item": "{{ page.url | absolute_url }}" }
+    ]
+  }
+  </script>
+  {% endunless %}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">


### PR DESCRIPTION
## What this PR does
Adds `BreadcrumbList` JSON-LD structured data to all inner pages (non-homepage) via `_layouts/default.html`. The schema is conditionally rendered using `{% unless page.url == "/" %}` so the homepage (which has Person + WebSite schema) is unaffected.

## Files changed
- `_layouts/default.html` — adds `{% unless page.url == "/" %}` block with BreadcrumbList script tag; uses `{{ page.title | jsonify }}` and `{{ page.url | absolute_url }}` for dynamic values

## Acceptance criteria (from Notion WBS)
- [x] BreadcrumbList JSON-LD present on all inner pages (experience, certifications, certifications/yearly, projects, education, awards)
- [x] Homepage does NOT have BreadcrumbList (verified: zero matches for BreadcrumbList in homepage source)
- [x] page.title and page.url are dynamically populated per page via Liquid
- [ ] Rich Results Test shows valid BreadcrumbList on inner pages (verify post-deploy)

## How to verify
```bash
# After merge, check an inner page:
curl -s https://abubakarriaz.com.pk/experience/ | grep -A 8 "BreadcrumbList"

# Confirm homepage has no BreadcrumbList:
curl -s https://abubakarriaz.com.pk/ | grep "BreadcrumbList"
# (should return empty)

# Use Rich Results Test for full validation:
# https://search.google.com/test/rich-results?url=https://abubakarriaz.com.pk/experience/
```

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 2. SEO Hardening → 2.3.1