### PR TITLE
SEO 3.1.1 — Add Open Graph meta tags to all pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {% seo %}
   {% feed_meta %}
+  <!-- Open Graph: supplementary tags not covered by jekyll-seo-tag -->
+  <meta property="og:image" content="{{ page.og_image | default: '/assets/images/og-default.png' | absolute_url }}" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
   <meta name="theme-color" content="#0f172a">
   <meta name="author" content="{{ site.author.name }}">
   <link rel="sitemap" type="application/xml" href="{{ '/sitemap.xml' | relative_url }}">


### PR DESCRIPTION
## What this PR does
Adds the Open Graph meta tag block to `_layouts/default.html` so all pages expose correct OG metadata for social sharing. Tags covered by `jekyll-seo-tag`'s `{% seo %}` are left as-is; this PR adds the three supplementary tags not generated by the plugin.

## Files changed
- `_layouts/default.html` — adds `og:image`, `og:image:width`, `og:image:height` after `{% seo %}`

## Acceptance criteria (from Notion WBS)
- [x] `og:type` visible in page source (via `{% seo %}`)
- [x] `og:url` visible in page source (via `{% seo %}`)
- [x] `og:title` visible in page source (via `{% seo %}`)
- [x] `og:description` visible in page source (via `{% seo %}`)
- [x] `og:image` visible in page source — falls back to `/assets/images/og-default.png`; supports per-page `og_image:` front matter override (for task 3.3.2)
- [x] `og:image:width` = 1200 visible in page source
- [x] `og:image:height` = 630 visible in page source
- [x] `og:site_name` visible in page source (via `{% seo %}`)
- [x] `og:locale` visible in page source (via `{% seo %}`)

## How to verify
```bash
curl -s https://abubakarriaz.com.pk/ | grep "og:"
curl -s https://abubakarriaz.com.pk/experience/ | grep "og:"
curl -s https://abubakarriaz.com.pk/certifications/ | grep "og:"
```
All 9 OG tags should be present on every page.

## Notes
- `og:locale`, `og:type`, `og:url`, `og:title`, `og:description`, `og:site_name` are already emitted by `jekyll-seo-tag` — no duplicates introduced
- `og:image` references `/assets/images/og-default.png` which will be created in task 3.3.1
- Pages can set `og_image:` in front matter to override the default image (used in task 3.3.2)

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 2. SEO Hardening → 3.1.1