### PR TITLE
SEO 3.2.1 — Add Twitter Card meta tags to all pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,12 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Twitter Card type: placed before jekyll-seo-tag so summary_large_image wins as first occurrence -->
+  <meta name="twitter:card" content="summary_large_image" />
   {% seo %}
   {% feed_meta %}
   <!-- Open Graph: supplementary tags not covered by jekyll-seo-tag -->
   <meta property="og:image" content="{{ page.og_image | default: '/assets/images/og-default.png' | absolute_url }}" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
+  <!-- Twitter Card: supplementary tags not covered by jekyll-seo-tag -->
+  <meta name="twitter:description" content="{{ page.description | default: site.description }}" />
+  <meta name="twitter:image" content="{{ page.og_image | default: '/assets/images/og-default.png' | absolute_url }}" />
   <meta name="theme-color" content="#0f172a">
   <meta name="author" content="{{ site.author.name }}">
   <link rel="sitemap" type="application/xml" href="{{ '/sitemap.xml' | relative_url }}">


### PR DESCRIPTION
## What this PR does
Adds Twitter Card meta tags to all pages via `_layouts/default.html`. Uses a pre-`{% seo %}` placement for `twitter:card` to ensure `summary_large_image` wins as the first occurrence (the jekyll-seo-tag plugin outputs `summary` when no page image is set). `twitter:description` and `twitter:image` are added as supplementary tags after the plugin block.

## Files changed
- `_layouts/default.html` — adds `twitter:card` before `{% seo %}` and `twitter:description` + `twitter:image` as supplementary tags

## Acceptance criteria (from Notion WBS)
- [x] `twitter:card: summary_large_image` visible in page source (line 7, before plugin output)
- [x] `twitter:title` visible in page source (handled by jekyll-seo-tag)
- [x] `twitter:description` visible in page source (supplementary, uses page description or site default)
- [x] `twitter:image` visible in page source (supplementary, uses `page.og_image` or `/assets/images/og-default.png` fallback)

## How to verify
```bash
# After merge and deploy (~1-2 min):
curl -s https://abubakarriaz.com.pk/ | grep -i "twitter:"
curl -s https://abubakarriaz.com.pk/experience/ | grep -i "twitter:"
curl -s https://abubakarriaz.com.pk/certifications/ | grep -i "twitter:"
# Expect: all 4 twitter: tags present on every page
```

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 2. SEO Hardening → 3.2.1