### PR TITLE
SEO 3.4.1 — Fix og:title, og:image:alt, and broken site.logo from Facebook Debugger

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ social:
     - https://learn.microsoft.com/en-us/users/abubakarriaz
     - https://blog.abubakarriaz.com.pk
 
-logo: /assets/images/og-image.png
+logo: /assets/images/og-default.png
 
 plugins:
   - jekyll-feed

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,12 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Twitter Card type: placed before jekyll-seo-tag so summary_large_image wins as first occurrence -->
   <meta name="twitter:card" content="summary_large_image" />
+  <!-- og:title override: placed before jekyll-seo-tag so Facebook picks up the first occurrence -->
+  {% if page.og_title %}
+  <meta property="og:title" content="{{ page.og_title }}" />
+  {% endif %}
   {% seo %}
   {% feed_meta %}
   <!-- Open Graph: supplementary tags not covered by jekyll-seo-tag -->
   <meta property="og:image" content="{{ page.og_image | default: '/assets/images/og-default.png' | absolute_url }}" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="{% if page.og_image_alt %}{{ page.og_image_alt }}{% else %}{{ site.author.name }} — Professional Portfolio{% endif %}" />
   <!-- Twitter Card: supplementary tags not covered by jekyll-seo-tag -->
   <meta name="twitter:description" content="{{ page.description | default: site.description }}" />
   <meta name="twitter:image" content="{{ page.og_image | default: '/assets/images/og-default.png' | absolute_url }}" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 description: "Abubakar Riaz — Associate Cloud Architect at Tkxel with 15+ years in cloud, DevOps, and .NET. Azure Solutions Architect Expert, MCT, Terraform Associate."
+og_title: "Abubakar Riaz — Cloud Architect & DevOps Engineer"
+og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio preview"
 ---
 
 <!-- ============================================================


### PR DESCRIPTION
## What this PR does
Fixes three real issues discovered during Facebook Sharing Debugger validation (task 3.4.1): empty `og:image:alt`, missing descriptive `og:title` on homepage, and a broken `site.logo` reference pointing to a non-existent file.

## Files changed
- `_config.yml` — fix `logo:` pointing to `og-image.png` (doesn't exist) → corrected to `og-default.png`
- `_layouts/default.html` — add `og:image:alt` tag with dynamic value; add `og:title` override support (injected before `{% seo %}` so Facebook picks up first occurrence)
- `index.html` — add `og_title` and `og_image_alt` front matter with real values for homepage

## Acceptance criteria (from Notion WBS)
- [x] `og:image:alt` is no longer empty — shows "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio preview" on homepage
- [x] `og:title` on homepage is descriptive — shows "Abubakar Riaz — Cloud Architect & DevOps Engineer"
- [x] `site.logo` references an existing file — `og-default.png` exists in `/assets/images/`
- [x] Inner pages get default `og:image:alt` — "Abubakar Riaz — Professional Portfolio"

## How to verify
After merge, run:
```bash
curl -s https://abubakarriaz.com.pk/ | grep -i "og:title\|og:image:alt"
# og:title first occurrence → "Abubakar Riaz — Cloud Architect & DevOps Engineer"
# og:image:alt → "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio preview"

curl -s https://abubakarriaz.com.pk/certifications/ | grep -i "og:image:alt"
# → "Abubakar Riaz — Professional Portfolio"
```
Then re-run Facebook Sharing Debugger (click "Scrape Again") to confirm no empty fields.

## What was NOT fixed (by design)
- `fb:app_id` warning — requires creating a real Facebook Developer App; optional for personal portfolio
- Duplicate `twitter:card` tags — harmless, Facebook correctly uses first occurrence (`summary_large_image`)

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 2. SEO Hardening → 3.4.1