### PR TITLE
SEO 4.3.2 — Preload critical font files

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Preload critical fonts (start fetch before CSS is parsed) -->
+  <link rel="preload" href="{{ '/assets/fonts/Inter-latin.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ '/assets/fonts/JetBrainsMono-latin.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin>
   <!-- Twitter Card: placed before jekyll-seo-tag so crawlers pick up our values first -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="{{ page.title | default: site.title }}" />


### PR DESCRIPTION
## What this PR does
Adds `<link rel="preload">` hints for the two self-hosted font files (Inter and JetBrains Mono) early in `<head>`, so the browser starts fetching them before CSS parsing discovers the `@font-face` rules. This eliminates the font-discovery delay and reduces CLS/FOUT.

## Files changed
- `_layouts/default.html` — Added two `<link rel="preload">` tags after the viewport meta tag

## Acceptance criteria (from Notion WBS)
- [x] `<link rel="preload" ... as="font" type="font/woff2" crossorigin>` present for Inter-latin.woff2
- [x] `<link rel="preload" ... as="font" type="font/woff2" crossorigin>` present for JetBrainsMono-latin.woff2
- [x] Preload hints appear on all pages (layout-level, not per-page)
- [x] `crossorigin` attribute included (required for font preloads per spec)

## How to verify
```bash
curl -s https://abubakarriaz.com.pk/ | grep -i "preload.*font"
curl -s https://abubakarriaz.com.pk/experience/ | grep -i "preload.*font"
```
Both should show two `<link rel="preload">` lines for the .woff2 files.

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 2. SEO Hardening → 4.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)