### PR TITLE
SEO: 4.4 — Inline critical CSS, defer non-critical CSS, and defer scripts

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -1,0 +1,234 @@
+/* Critical CSS — inlined in <head> to eliminate render-blocking stylesheet
+   Contains only above-the-fold styles: fonts, tokens, reset, navbar, hero, page-hero */
+
+@font-face {
+  font-family: 'Inter';
+  src: url('/assets/fonts/Inter-latin.woff2') format('woff2');
+  font-weight: 300 900;
+  font-style: normal;
+  font-display: swap;
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'JetBrains Mono';
+  src: url('/assets/fonts/JetBrainsMono-latin.woff2') format('woff2');
+  font-weight: 400 600;
+  font-style: normal;
+  font-display: swap;
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+:root {
+  --bg-primary:    #050810;
+  --bg-secondary:  #0a0f1e;
+  --bg-card:       rgba(13, 22, 45, 0.75);
+  --bg-card-solid: #0d162d;
+  --accent:        #6366f1;
+  --accent-cyan:   #22d3ee;
+  --accent-violet: #8b5cf6;
+  --gradient:      linear-gradient(135deg, #6366f1 0%, #22d3ee 100%);
+  --gradient-text: linear-gradient(135deg, #818cf8 0%, #22d3ee 100%);
+  --border:        rgba(99, 102, 241, 0.15);
+  --border-hover:  rgba(99, 102, 241, 0.45);
+  --text-primary:  #f1f5f9;
+  --text-secondary:#94a3b8;
+  --text-muted:    #475569;
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --radius:    12px;
+  --radius-lg: 20px;
+  --radius-xl: 28px;
+  --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.4);
+  --shadow-glow: 0 0 40px rgba(99, 102, 241, 0.18);
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; font-size: 16px; }
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+a { color: inherit; text-decoration: none; }
+ul { list-style: none; }
+img { max-width: 100%; display: block; }
+
+.container { width: 100%; max-width: 1120px; margin: 0 auto; padding: 0 24px; }
+.section { padding: 100px 0; }
+.section-dark { background-color: var(--bg-secondary); }
+
+.gradient-text {
+  background: var(--gradient-text);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.navbar {
+  position: fixed; top: 0; left: 0; right: 0;
+  z-index: 1000; padding: 20px 0;
+  transition: var(--transition);
+}
+.navbar.scrolled {
+  padding: 12px 0;
+  background: rgba(5, 8, 16, 0.85);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border-bottom: 1px solid var(--border);
+}
+.nav-container {
+  max-width: 1120px; margin: 0 auto; padding: 0 24px;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.nav-logo {
+  font-family: var(--font-mono); font-size: 1.2rem;
+  font-weight: 700; color: var(--text-primary); letter-spacing: -0.02em;
+}
+.nav-logo .bracket { color: var(--accent-cyan); }
+.nav-links { display: flex; gap: 36px; align-items: center; }
+.nav-link {
+  font-size: 0.9rem; font-weight: 500; color: var(--text-secondary);
+  transition: var(--transition); position: relative;
+}
+.nav-link::after {
+  content: ''; position: absolute; bottom: -4px; left: 0;
+  width: 0; height: 2px; background: var(--gradient);
+  border-radius: 2px; transition: width 0.3s ease;
+}
+.nav-link:hover, .nav-link.active { color: var(--text-primary); }
+.nav-link:hover::after, .nav-link.active::after { width: 100%; }
+.nav-toggle {
+  display: none; flex-direction: column; gap: 5px;
+  background: none; border: none; cursor: pointer; padding: 4px;
+}
+.nav-toggle span {
+  display: block; width: 24px; height: 2px;
+  background: var(--text-primary); border-radius: 2px;
+  transition: var(--transition);
+}
+.nav-resume-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; font-size: 0.85rem; font-weight: 600;
+  color: var(--accent-cyan); border: 1.5px solid var(--accent-cyan);
+  border-radius: 6px; transition: var(--transition); white-space: nowrap;
+}
+.nav-resume-btn:hover { background: var(--accent-cyan); color: #0a0a0f; }
+
+.hero {
+  position: relative; min-height: 100vh;
+  display: flex; align-items: center; overflow: hidden;
+}
+.hero-bg { position: absolute; inset: 0; z-index: 0; }
+.orb { position: absolute; border-radius: 50%; filter: blur(80px); pointer-events: none; }
+.orb-1 {
+  width: 600px; height: 600px;
+  background: radial-gradient(circle, rgba(99,102,241,0.25) 0%, transparent 70%);
+  top: -150px; right: -100px;
+}
+.orb-2 {
+  width: 450px; height: 450px;
+  background: radial-gradient(circle, rgba(34,211,238,0.18) 0%, transparent 70%);
+  bottom: -80px; left: 5%;
+}
+.grid-overlay {
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(rgba(99,102,241,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(99,102,241,0.04) 1px, transparent 1px);
+  background-size: 60px 60px;
+}
+.hero-content {
+  position: relative; z-index: 1;
+  display: grid; grid-template-columns: 1fr 380px;
+  gap: 64px; align-items: center;
+  padding-top: 80px; padding-bottom: 80px;
+}
+.hero-greeting {
+  font-family: var(--font-mono); font-size: 1rem;
+  color: var(--accent-cyan); letter-spacing: 0.05em; margin-bottom: 12px;
+}
+.hero-name {
+  font-size: clamp(3.2rem, 7vw, 5.5rem); font-weight: 900;
+  line-height: 1.05; letter-spacing: -0.03em; margin-bottom: 20px;
+}
+.hero-role {
+  font-size: 1.15rem; font-weight: 500; color: var(--text-secondary);
+  margin-bottom: 24px; min-height: 1.8em;
+}
+.hero-role .role-text { color: var(--accent); font-weight: 600; }
+.hero-role .cursor { color: var(--accent-cyan); font-weight: 300; }
+.hero-desc {
+  font-size: 1.05rem; color: var(--text-secondary);
+  line-height: 1.75; max-width: 520px; margin-bottom: 36px;
+}
+.hero-actions { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 32px; }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 28px; border-radius: var(--radius);
+  font-size: 0.95rem; font-weight: 600; letter-spacing: 0.01em;
+  transition: var(--transition); cursor: pointer; border: none; white-space: nowrap;
+}
+.btn-primary {
+  background: var(--gradient); color: #fff;
+  box-shadow: 0 4px 20px rgba(99, 102, 241, 0.35);
+}
+.btn-outline {
+  background: transparent; color: var(--text-primary);
+  border: 1px solid var(--border-hover);
+}
+
+.page-hero {
+  padding: 140px 0 64px; background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border); position: relative; overflow: hidden;
+}
+.page-hero::before {
+  content: ''; position: absolute; inset: 0;
+  background-image:
+    linear-gradient(rgba(99,102,241,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(99,102,241,0.04) 1px, transparent 1px);
+  background-size: 60px 60px;
+}
+.page-hero-orb {
+  position: absolute; width: 400px; height: 400px; border-radius: 50%;
+  background: radial-gradient(circle, rgba(99,102,241,0.2) 0%, transparent 70%);
+  filter: blur(80px); top: -100px; right: -80px; pointer-events: none;
+}
+.page-hero-inner { position: relative; z-index: 1; }
+.page-title {
+  font-size: clamp(2.5rem, 5vw, 3.8rem); font-weight: 900;
+  letter-spacing: -0.03em; line-height: 1.1; margin-bottom: 16px;
+}
+.page-subtitle { font-size: 1.05rem; color: var(--text-secondary); max-width: 560px; }
+
+.breadcrumb {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 20px; font-size: 0.85rem; color: var(--text-muted);
+}
+.breadcrumb a { color: var(--accent-cyan); transition: var(--transition); }
+.breadcrumb-sep { color: var(--text-muted); }
+
+/* Mobile navbar breakpoint */
+@media (max-width: 768px) {
+  .nav-links {
+    display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(5, 8, 16, 0.97); backdrop-filter: blur(24px);
+    flex-direction: column; justify-content: center; align-items: center;
+    gap: 40px; z-index: 999;
+  }
+  .nav-links.open { display: flex; }
+  .nav-link { font-size: 1.5rem; }
+  .nav-toggle { display: flex; z-index: 1000; }
+  .nav-resume-btn { padding: 6px 10px; font-size: 0; gap: 0; }
+  .nav-resume-btn svg { width: 18px; height: 18px; }
+  .hero-name { font-size: clamp(2.8rem, 10vw, 4rem); }
+}
+
+@media (max-width: 1024px) {
+  .hero-content { grid-template-columns: 1fr; gap: 48px; }
+}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,7 +91,11 @@
   }
   </script>
   {% endunless %}
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  <!-- Critical CSS: inlined to eliminate render-blocking stylesheet -->
+  <style>{% include critical.css %}</style>
+  <!-- Non-critical CSS: deferred via media="print" swap trick -->
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}"></noscript>
 </head>
 <body>
 
@@ -149,6 +153,6 @@
     gtag('js', new Date());
     gtag('config', 'G-T8M8FBW7SY');
   </script>
-  <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
+  <script defer src="{{ '/assets/js/main.js' | relative_url }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## What this PR does
Implements all three CSS & JS optimization tasks from Sprint 4.4: inlines critical above-the-fold CSS, defers non-critical CSS loading, and adds `defer` to script tags — eliminating render-blocking resources.

## Files changed
- `_includes/critical.css` (new) — Extracted above-the-fold styles (font-faces, design tokens, reset, navbar, hero, page-hero, breadcrumb, buttons) for inline embedding
- `_layouts/default.html` — Replaces render-blocking `<link>` with inline `<style>` + deferred CSS load; adds `defer` to `main.js`

## Acceptance criteria (from Notion WBS)
- [x] **4.4.1** Critical CSS inlined in `<head>` — FCP should improve (no render-blocking stylesheet)
- [x] **4.4.2** Non-critical CSS deferred with `media="print" onload="this.media='all'"` + `<noscript>` fallback
- [x] **4.4.3** `defer` attribute added to `main.js` script tag (GA already has `async`)

## How to verify
1. View page source on any page — confirm `<style>` block with critical CSS in `<head>`
2. View page source — confirm `<link ... media="print" onload="this.media='all'">` for main.css
3. View page source — confirm `<noscript>` fallback for main.css
4. View page source — confirm `<script defer src="/assets/js/main.js">`
5. Run PageSpeed Insights — no render-blocking CSS or JS warnings
6. All 7 pages return HTTP 200 (tested locally)

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 2. SEO Hardening → 4.4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)