### PR TITLE
Enable Sprint 4 & 5 SEO tests

### DIFF
--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -321,7 +321,8 @@ test.describe('Sprint 4 — Performance & Core Web Vitals', () => {
 
     for (const preload of fontPreloads) {
       const crossorigin = await preload.getAttribute('crossorigin');
-      expect(crossorigin, 'Font preload must have crossorigin attribute').toBeTruthy();
+      // crossorigin without a value returns "" (anonymous), which is valid
+      expect(crossorigin, 'Font preload must have crossorigin attribute').not.toBeNull();
     }
   });
 
@@ -464,7 +465,10 @@ test.describe('Sprint 5 — Final SEO Touches', () => {
       expect(await homeLink.isVisible(), '404 page should have a link back to homepage').toBe(true);
     });
 
+    // Skip on local (http) builds — mixed content only applies to HTTPS sites
     test('[task-5.3.2] no HTTP resources loaded on HTTPS pages (no mixed content)', async ({ page }) => {
+      test.skip(BASE_URL.startsWith('http://'), 'Mixed content test only applies to HTTPS');
+
       const mixedContent: string[] = [];
       page.on('response', response => {
         const url = response.url();


### PR DESCRIPTION
## Summary
- **Enable** Sprint 4 (Performance) and Sprint 5 (Final SEO) test suites — previously fully skipped via `test.describe.skip`
- **Remove** task-4.2.4 (hero image preload) — not applicable since the site uses a CSS-only hero
- **Fix** task-4.3.2: `crossorigin` without a value returns `""` (valid anonymous mode) — check `not null` instead of truthy
- **Fix** task-5.3.2: skip mixed content test on local HTTP builds (only meaningful on HTTPS)
- **Keep skipped** 3 tests not yet implemented: favicon.ico (5.3.1), theme-color #0078D4 (5.3.3), custom 404 page (5.3.4)

## Test plan
- [x] CI pipeline runs Sprint 4 & 5 tests successfully on PR build
- [x] Skipped tests show as skipped (not failed) in Playwright report
- [ ] Merge and confirm production run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)