### PR TITLE
Audience 1.2.1 — Add newsletter CTA to homepage hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       <div class="hero-actions">
         <a href="https://blog.abubakarriaz.com.pk" class="btn btn-primary">Explore My Blog</a>
         <a href="#certifications" class="btn btn-outline">View Certifications</a>
+        <a href="https://www.linkedin.com/newsletters/7440660160471281665/" target="_blank" rel="noopener" class="btn btn-outline">Subscribe to Newsletter →</a>
       </div>
       <div class="hero-social">
         <a href="https://github.com/mabubakarriaz" target="_blank" rel="noopener" class="social-link">GitHub</a>


### PR DESCRIPTION
## What this PR does
Adds a "Subscribe to Newsletter →" CTA button to the homepage hero section, linking to the LinkedIn newsletter "Think you know DevOps?" — giving visitors a direct path to subscribe.

## Files changed
- `index.html` — Added outline-style newsletter CTA button in the `hero-actions` div

## Acceptance criteria (from Notion WBS)
- [ ] Newsletter CTA visible on homepage hero section
- [ ] Button opens LinkedIn newsletter page in new tab
- [ ] Styled as outline button (secondary) to differentiate from primary CTA
- [ ] Uses `target="_blank" rel="noopener"`

## How to verify
1. Open `abubakarriaz.com.pk` (or local Jekyll server)
2. Confirm "Subscribe to Newsletter →" button appears in the hero section below "Explore My Blog" and "View Certifications"
3. Click the button — should open `https://www.linkedin.com/newsletters/7440660160471281665/` in a new tab
4. On mobile (≤480px), confirm all three buttons stack vertically

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 3. Audience Infrastructure → 1.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)