### PR TITLE
Audience 1.2.2 — Add newsletter CTA to site footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -144,6 +144,10 @@
           </a>
         </div>
       </div>
+      <div class="footer-newsletter">
+        <p>Think you know DevOps? Subscribe to my LinkedIn newsletter for insights on Cloud, DevOps &amp; Architecture.</p>
+        <a href="https://www.linkedin.com/newsletters/7440660160471281665/" target="_blank" rel="noopener" class="btn btn-outline">Subscribe to Newsletter →</a>
+      </div>
       <div class="footer-bottom">
         <p>&copy; {{ 'now' | date: "%Y" }} Abubakar Riaz &mdash; Built with Jekyll &amp; hosted on GitHub Pages.</p>
       </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1398,6 +1398,22 @@ img { max-width: 100%; display: block; }
   color: var(--text-muted);
 }
 
+.footer-newsletter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+.footer-newsletter p {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  max-width: 480px;
+}
+
 /* ============================================================
    SCROLL ANIMATIONS
    ============================================================ */


### PR DESCRIPTION
## What this PR does
Adds a newsletter CTA row to the site footer on all pages, showing a tagline and a "Subscribe to Newsletter →" button linking to the LinkedIn newsletter. The CTA sits between the footer brand/social row and the copyright line.

## Files changed
- `_layouts/default.html` — added `.footer-newsletter` div with tagline and subscribe button
- `assets/css/main.css` — added `.footer-newsletter` and `.footer-newsletter p` styles

## Acceptance criteria (from Notion WBS)
- [ ] Newsletter CTA is visible in the footer on every page (layout-level change)
- [ ] CTA links to the LinkedIn newsletter URL with `target="_blank" rel="noopener"`
- [ ] Button uses existing `.btn .btn-outline` styles, consistent with hero CTA

## How to verify
1. Open any page on the site (home, certifications, experience, etc.)
2. Scroll to the footer — verify the newsletter tagline and "Subscribe to Newsletter →" button appear between the social icons row and the copyright line
3. Click the button — verify it opens `https://www.linkedin.com/newsletters/7440660160471281665/` in a new tab
4. Check page source — verify `rel="noopener"` is present on the link

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 3. Audience Infrastructure → 1.2.2