### PR TITLE
Audience: 1.2.3 — Add newsletter banner section on homepage

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1415,6 +1415,69 @@ img { max-width: 100%; display: block; }
 }
 
 /* ============================================================
+   NEWSLETTER BANNER
+   ============================================================ */
+.newsletter-banner {
+  padding: 80px 0;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  position: relative;
+  overflow: hidden;
+}
+.newsletter-banner::before {
+  content: '';
+  position: absolute;
+  width: 500px;
+  height: 500px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(99,102,241,0.12) 0%, transparent 70%);
+  filter: blur(80px);
+  top: -200px;
+  right: -100px;
+  pointer-events: none;
+}
+.newsletter-banner-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+  flex-wrap: wrap;
+}
+.newsletter-banner-text {
+  max-width: 560px;
+}
+.newsletter-banner-title {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 12px 0 16px;
+}
+.newsletter-banner-desc {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+.newsletter-banner-action {
+  flex-shrink: 0;
+}
+.btn-lg {
+  padding: 16px 32px;
+  font-size: 1.05rem;
+}
+
+@media (max-width: 768px) {
+  .newsletter-banner { padding: 56px 0; }
+  .newsletter-banner-content {
+    flex-direction: column;
+    text-align: center;
+  }
+  .newsletter-banner-title { font-size: 1.6rem; }
+  .newsletter-banner-action { width: 100%; }
+  .newsletter-banner-action .btn { width: 100%; text-align: center; }
+}
+
+/* ============================================================
    SCROLL ANIMATIONS
    ============================================================ */
 .animate-on-scroll {

--- a/index.html
+++ b/index.html
@@ -430,6 +430,27 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
 </section>
 
 <!-- ============================================================
+     NEWSLETTER BANNER
+     ============================================================ -->
+<section class="newsletter-banner" id="newsletter">
+  <div class="container">
+    <div class="newsletter-banner-content animate-on-scroll">
+      <div class="newsletter-banner-text">
+        <span class="section-tag">Stay Updated</span>
+        <h2 class="newsletter-banner-title">Think you know <span class="gradient-text">DevOps?</span></h2>
+        <p class="newsletter-banner-desc">
+          Subscribe to my LinkedIn newsletter for insights on cloud architecture,
+          CI/CD pipelines, Azure, and modern DevOps practices — straight to your inbox.
+        </p>
+      </div>
+      <div class="newsletter-banner-action">
+        <a href="https://www.linkedin.com/newsletters/7440660160471281665/" target="_blank" rel="noopener" class="btn btn-primary btn-lg">Subscribe on LinkedIn →</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
      EDUCATION
      ============================================================ -->
 <section class="section" id="education">

--- a/tests/audience.spec.ts
+++ b/tests/audience.spec.ts
@@ -79,7 +79,6 @@ test.describe('Sprint 1 — Newsletter CTAs & LinkedIn Integration', () => {
     });
 
     test('[task-1.2.3] homepage has a dedicated newsletter banner section', async ({ page }) => {
-      test.skip(true, 'task 1.2.3 not yet implemented — newsletter banner section pending');
       await page.goto('/');
 
       const newsletterSection = page.locator(


### PR DESCRIPTION
## What this PR does
Adds a dedicated newsletter banner section on the homepage, placed between the Projects and Education sections. The banner promotes the "Think you know DevOps?" LinkedIn newsletter with a prominent CTA button.

## Files changed
- `index.html` — Added newsletter banner section HTML between Projects and Education
- `assets/css/main.css` — Added `.newsletter-banner` styles with responsive layout and decorative gradient orb
- `tests/audience.spec.ts` — Enabled the task-1.2.3 test (removed `test.skip`)

## Acceptance criteria (from Notion WBS)
- [ ] Dedicated newsletter banner section is visible on the homepage
- [ ] Banner is placed between Projects and Education sections
- [ ] Banner contains newsletter name "Think you know DevOps?"
- [ ] CTA links to LinkedIn newsletter URL with `target="_blank" rel="noopener"`
- [ ] Section is responsive on mobile
- [ ] Playwright test for task-1.2.3 passes

## How to verify
1. Open the homepage and scroll to the section between Projects and Education
2. Verify the newsletter banner is visible with the title "Think you know DevOps?"
3. Click "Subscribe on LinkedIn →" — should open LinkedIn newsletter in a new tab
4. Resize browser to mobile width — banner should stack vertically with full-width CTA
5. Run `npx playwright test audience.spec.ts --grep "task-1.2.3"` to confirm the test passes

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 3. Audience Infrastructure → 1.2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)