### PR TITLE
Audience 2.1 — Surface Hashnode RSS Feed

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -147,6 +147,10 @@
       <div class="footer-newsletter">
         <p>Think you know DevOps? Subscribe to my LinkedIn newsletter for insights on Cloud, DevOps &amp; Architecture.</p>
         <a href="https://www.linkedin.com/newsletters/7440660160471281665/" target="_blank" rel="noopener" class="btn btn-outline">Subscribe to Newsletter →</a>
+        <a href="https://blog.abubakarriaz.com.pk/rss.xml" target="_blank" rel="noopener" class="footer-rss-link" aria-label="RSS Feed">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20C4.98 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/></svg>
+          RSS Feed
+        </a>
       </div>
       <div class="footer-bottom">
         <p>&copy; {{ 'now' | date: "%Y" }} Abubakar Riaz &mdash; Built with Jekyll &amp; hosted on GitHub Pages.</p>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1413,6 +1413,17 @@ img { max-width: 100%; display: block; }
   color: var(--text-muted);
   max-width: 480px;
 }
+.footer-rss-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color 0.2s;
+  white-space: nowrap;
+}
+.footer-rss-link:hover { color: var(--accent-cyan); }
 
 /* ============================================================
    NEWSLETTER BANNER


### PR DESCRIPTION
## What this PR does
Adds a visible RSS feed link to the main portfolio site footer (task 2.1.4), making the Hashnode blog's RSS feed discoverable from every page on the portfolio site. The link appears in the footer newsletter section, styled consistently with the existing footer design.

## Files changed
- `_layouts/default.html` — added RSS feed link (`https://blog.abubakarriaz.com.pk/rss.xml`) with SVG icon and "RSS Feed" label in the footer newsletter section
- `assets/css/main.css` — added `.footer-rss-link` styles (inline-flex, muted color, hover accent)

## Acceptance criteria (from Notion WBS)
- [x] RSS link visible in footer on all portfolio pages
- [x] Links to `https://blog.abubakarriaz.com.pk/rss.xml`
- [x] Opens in new tab with `rel="noopener"`
- [x] RSS icon + "RSS Feed" label displayed

## How to verify
1. Open any page on the portfolio (home, certifications, experience, etc.)
2. Scroll to the footer — the RSS Feed link should appear below the Subscribe to Newsletter button
3. Click it — should open `https://blog.abubakarriaz.com.pk/rss.xml` in a new tab showing valid XML

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 3. Audience Infrastructure → 2.1.4