### PR TITLE
Audience 2.2 — Social sharing links across portfolio site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -142,6 +142,12 @@
           <a href="https://www.linkedin.com/in/mabubakarriaz" target="_blank" rel="me noopener noreferrer" class="footer-icon-link" aria-label="LinkedIn">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
           </a>
+          <a href="https://learn.microsoft.com/en-us/users/abubakarriaz" target="_blank" rel="me noopener noreferrer" class="footer-icon-link" aria-label="Microsoft Learn">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.5 2L2 7v10l9.5 5 9.5-5V7L11.5 2zm0 1.8L19 7.9v8.2l-7.5 3.95L4 16.1V7.9l7.5-4.1zM11.5 8a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7zm0 1.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4z"/></svg>
+          </a>
+          <a href="https://blog.abubakarriaz.com.pk" target="_blank" rel="me noopener noreferrer" class="footer-icon-link" aria-label="Hashnode Blog">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.987 0C5.366 0 0 5.367 0 11.987 0 18.62 5.367 24 11.987 24 18.62 24 24 18.62 24 11.987 24 5.367 18.62 0 11.987 0zm.026 6.063a5.923 5.923 0 1 1 0 11.847 5.923 5.923 0 0 1 0-11.847z"/></svg>
+          </a>
         </div>
       </div>
       <div class="footer-newsletter">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1630,3 +1630,55 @@ img { max-width: 100%; display: block; }
   .badge-card { min-width: unset; }
   .hero-badge-stack { flex-direction: column; }
 }
+
+/* ============================================================
+   SHARE BAR
+   ============================================================ */
+.share-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 20px 40px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  margin-top: 16px;
+}
+
+.share-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-right: 4px;
+}
+
+.share-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.04);
+  color: var(--text-secondary);
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.share-btn:hover {
+  background: rgba(255,255,255,0.09);
+  color: var(--text-primary);
+  border-color: rgba(255,255,255,0.2);
+  text-decoration: none;
+}
+
+.share-btn-copy {
+  font-family: inherit;
+}
+
+@media (max-width: 768px) {
+  .share-bar { padding: 16px 20px; gap: 8px; }
+}

--- a/certifications/index.html
+++ b/certifications/index.html
@@ -479,4 +479,20 @@ og_image: /assets/images/og-certifications.png
     </div>
 
   </div>
+
+  <div class="share-bar">
+    <span class="share-label">Share this page:</span>
+    <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ page.url | absolute_url | url_encode }}" target="_blank" rel="noopener" class="share-btn share-btn-linkedin">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+      Share on LinkedIn
+    </a>
+    <a href="https://twitter.com/intent/tweet?url={{ page.url | absolute_url | url_encode }}&text={{ page.title | url_encode }}" target="_blank" rel="noopener" class="share-btn share-btn-x">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg>
+      Share on X
+    </a>
+    <button class="share-btn share-btn-copy" onclick="navigator.clipboard.writeText(window.location.href).then(function(){var b=this;b.textContent='Copied!';setTimeout(function(){b.innerHTML='<svg width=&quot;14&quot; height=&quot;14&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;none&quot; stroke=&quot;currentColor&quot; stroke-width=&quot;2&quot; aria-hidden=&quot;true&quot;><rect x=&quot;9&quot; y=&quot;9&quot; width=&quot;13&quot; height=&quot;13&quot; rx=&quot;2&quot;/><path d=&quot;M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1&quot;/></svg> Copy Link';},2000)}.bind(this))">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+      Copy Link
+    </button>
+  </div>
 </section>

--- a/experience/index.html
+++ b/experience/index.html
@@ -480,4 +480,20 @@ og_image: /assets/images/og-experience.png
 
     </div>
   </div>
+
+  <div class="share-bar">
+    <span class="share-label">Share this page:</span>
+    <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ page.url | absolute_url | url_encode }}" target="_blank" rel="noopener" class="share-btn share-btn-linkedin">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+      Share on LinkedIn
+    </a>
+    <a href="https://twitter.com/intent/tweet?url={{ page.url | absolute_url | url_encode }}&text={{ page.title | url_encode }}" target="_blank" rel="noopener" class="share-btn share-btn-x">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg>
+      Share on X
+    </a>
+    <button class="share-btn share-btn-copy" onclick="navigator.clipboard.writeText(window.location.href).then(function(){var b=this;b.textContent='Copied!';setTimeout(function(){b.innerHTML='<svg width=&quot;14&quot; height=&quot;14&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;none&quot; stroke=&quot;currentColor&quot; stroke-width=&quot;2&quot; aria-hidden=&quot;true&quot;><rect x=&quot;9&quot; y=&quot;9&quot; width=&quot;13&quot; height=&quot;13&quot; rx=&quot;2&quot;/><path d=&quot;M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1&quot;/></svg> Copy Link';},2000)}.bind(this))">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+      Copy Link
+    </button>
+  </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,8 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
         <a href="https://www.linkedin.com/in/mabubakarriaz" target="_blank" rel="noopener" class="social-link">LinkedIn</a>
         <span class="social-divider">·</span>
         <a href="https://learn.microsoft.com/en-us/users/abubakarriaz" target="_blank" rel="noopener" class="social-link">Microsoft Learn</a>
+        <span class="social-divider">·</span>
+        <a href="https://blog.abubakarriaz.com.pk" target="_blank" rel="noopener" class="social-link">Hashnode</a>
       </div>
     </div>
 

--- a/projects/index.html
+++ b/projects/index.html
@@ -235,4 +235,20 @@ og_image: /assets/images/og-projects.png
       <div class="cr-item"><div class="cr-dot"></div>Franchise Complain Executive API</div>
     </div>
   </div>
+
+  <div class="share-bar">
+    <span class="share-label">Share this page:</span>
+    <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ page.url | absolute_url | url_encode }}" target="_blank" rel="noopener" class="share-btn share-btn-linkedin">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+      Share on LinkedIn
+    </a>
+    <a href="https://twitter.com/intent/tweet?url={{ page.url | absolute_url | url_encode }}&text={{ page.title | url_encode }}" target="_blank" rel="noopener" class="share-btn share-btn-x">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg>
+      Share on X
+    </a>
+    <button class="share-btn share-btn-copy" onclick="navigator.clipboard.writeText(window.location.href).then(function(){var b=this;b.textContent='Copied!';setTimeout(function(){b.innerHTML='<svg width=&quot;14&quot; height=&quot;14&quot; viewBox=&quot;0 0 24 24&quot; fill=&quot;none&quot; stroke=&quot;currentColor&quot; stroke-width=&quot;2&quot; aria-hidden=&quot;true&quot;><rect x=&quot;9&quot; y=&quot;9&quot; width=&quot;13&quot; height=&quot;13&quot; rx=&quot;2&quot;/><path d=&quot;M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1&quot;/></svg> Copy Link';},2000)}.bind(this))">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+      Copy Link
+    </button>
+  </div>
 </section>


### PR DESCRIPTION
## What this PR does
Implements all three tasks in Sprint 2.2 (Social Sharing Links on Portfolio):
- Adds Hashnode blog link to homepage hero social row
- Adds Microsoft Learn and Hashnode icons to the site footer icon row (all pages)
- Adds LinkedIn + X + Copy Link share buttons to the Experience, Projects, and Certifications inner pages

## Files changed
- `index.html` — adds Hashnode to hero-social links (2.2.1)
- `_layouts/default.html` — adds MS Learn + Hashnode SVG icons to footer-social (2.2.2)
- `experience/index.html` — adds share bar at bottom of page (2.2.3)
- `projects/index.html` — adds share bar at bottom of last section (2.2.3)
- `certifications/index.html` — adds share bar at bottom of page (2.2.3)
- `assets/css/main.css` — adds `.share-bar` and `.share-btn` styles

## Acceptance criteria (from Notion WBS)
- [x] All social profiles (GitHub, LinkedIn, MS Learn, Hashnode) accessible from hero section
- [x] Social links (GitHub, LinkedIn, MS Learn, Hashnode) visible in footer on every page
- [x] Share buttons (LinkedIn, X, Copy Link) visible on Experience, Projects, and Certifications pages
- [x] All external links use `target="_blank" rel="noopener"`

## How to verify
1. **Hero (2.2.1):** Open homepage → hero shows GitHub · LinkedIn · Microsoft Learn · Hashnode; all open correct profiles in new tab
2. **Footer (2.2.2):** Any page footer → 4 icon links (GitHub, LinkedIn, MS Learn, Hashnode) all open correct profiles in new tab
3. **Share bar (2.2.3):** Open /experience, /projects, /certifications → share bar appears at bottom with 3 buttons
   - "Share on LinkedIn" → opens LinkedIn share dialog in new tab with correct URL
   - "Share on X" → opens X tweet intent in new tab with page URL + title
   - "Copy Link" → copies current URL to clipboard; button text briefly shows "Copied!"

## Notion task
Streams → MVP → Personal Portfolio → Roadmap → 3. Audience Infrastructure → 2.2