### PR TITLE
Adapt: fix mobile horizontal overflow in hero and timeline

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -415,7 +415,9 @@ img { max-width: 100%; display: block; }
 @media (max-width: 768px) {
   .hero-stage-inner { transform: none; }
   .fp-pipeline, .fp-stack { display: none; }
-  .fp-console { max-width: none; }
+  /* Full-bleed the console to the column width; drop the desktop offset margin
+     so its fixed 360px width can't push the hero text off-screen. */
+  .fp-console { width: 100%; max-width: 100%; margin-left: 0; margin-right: 0; }
 }
 .console-bar {
   display: flex; align-items: center; gap: 10px;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2003,7 +2003,9 @@ img { max-width: 100%; display: block; }
    ============================================================ */
 @media (max-width: 1024px) {
   .hero-content {
-    grid-template-columns: 1fr;
+    /* minmax(0, 1fr) lets the single track shrink below the console panel's
+       intrinsic 360px width instead of forcing the whole hero past the viewport. */
+    grid-template-columns: minmax(0, 1fr);
     gap: 48px;
   }
   .about-grid {
@@ -2049,6 +2051,10 @@ img { max-width: 100%; display: block; }
   .timeline-item { grid-template-columns: 24px 1fr; gap: 16px; }
   .timeline-card { padding: 20px; }
   .timeline-header { flex-wrap: wrap; }
+  /* The longest date pill ("… · 4 yrs 2 mos") is wider than a 320px viewport as
+     one nowrap line; let it shrink and wrap so it can't drag the card off-screen.
+     flex-shrink must be re-enabled or it stays pinned at max-content width. */
+  .timeline-date { white-space: normal; flex-shrink: 1; }
 
   .cert-grid { grid-template-columns: 1fr 1fr; }
   .projects-grid { grid-template-columns: 1fr; }
@@ -2063,6 +2069,9 @@ img { max-width: 100%; display: block; }
   .cert-grid { grid-template-columns: 1fr; }
   .hero-actions { flex-direction: column; }
   .hero-actions .btn { width: 100%; justify-content: center; }
+  /* The "available for…" pill is too long for narrow phones; shrink it and
+     let it wrap to two lines rather than spill past the right edge. */
+  .hero-status { font-size: 0.7rem; padding: 5px 12px; white-space: normal; line-height: 1.5; }
   .console-body { padding: 18px 16px; }
   .console-cert { flex-wrap: wrap; gap: 6px 10px; }
   .console-cert .code { margin-left: auto; }


### PR DESCRIPTION
## Summary

The Control Plane redesign (#56) overflowed the viewport horizontally on phones. This pass adapts it to mobile with viewport-scoped CSS only — desktop rendering is unchanged.

Root causes found via Chrome mobile emulation (not `--window-size`, which doesn't emulate the mobile viewport and gave misleading clipping):

- **Hero, ~26px overflow at 390px.** The single-column hero grid track sized itself to the console panel's intrinsic `360px width + 32px margin = 392px`, dragging the hero text and status pill off-screen.
- **Hero status pill** ("available for cloud architecture & training") was a long line spilling past the right edge on narrow phones.
- **Timeline, overflow at ≤360px.** `.timeline-date` was `white-space: nowrap` with `flex-shrink: 0`; the longest value ("Aug 2018 – Sep 2022 · 4 yrs 2 mos") was a 269px unbreakable line that forced the card past a 320px viewport.

## Changes

- `assets/css/main.css`
  - Hero grid track → `minmax(0, 1fr)` at ≤1024px so it can shrink below the console's width.
  - Status pill shrinks + wraps at ≤480px.
  - `.timeline-date` → `white-space: normal; flex-shrink: 1` at ≤768px so the date wraps instead of pinning at max-content.
- `_includes/critical.css`
  - Hero console panel goes full-bleed (`width: 100%`, margins reset) at ≤768px instead of keeping its 360px desktop width.

## Verification

`scrollWidth == viewport` (zero horizontal overflow) confirmed on the home and experience pages at **320 / 360 / 390 / 414 / 768 / 1024 / 1280** via Chrome DevTools-protocol mobile emulation. Visual spot-checks at 320/390 confirm the hero, console, status pill, and timeline all read correctly.

The certifications, projects, education, and awards pages were already clean on mobile and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
