### PR TITLE
Reshape homepage into story form; de-slop emoji and copy

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-06-02T14:23:45.684Z",
+  "generatedAt": "2026-06-03T00:00:00Z",
   "title": "Design System: Abubakar Riaz Portfolio",
   "extensions": {
     "colorMeta": {
@@ -241,6 +241,8 @@
       "Monospace (JetBrains Mono) reserved for telemetry: dates, eyebrows, metadata, the logo, the cursor.",
       "Depth via blur, glow, and translucency — never via heavy drop shadows or borders.",
       "Glow-on-hover and small directional nudges as the interaction signature.",
+      "A story read top to bottom: voice-led section titles, a section-lead connector per section, and the ~/ kicker carrying one terminal session through the page (The Guided-Traversal Rule).",
+      "No emoji and no pictorial card icons: identity comes from structure (issuer bars, gradient signal-nodes, the deploy-panel window bar, mono telemetry).",
       "Mobile is a curated story, not a scaled-down desktop: tangential sections (Projects, Education) drop away and the Engage to Newsletter CTA closes the scroll (The Mobile-Story Rule)."
     ],
     "rules": [
@@ -273,6 +275,16 @@
         "name": "The Mobile-Story Rule",
         "body": "On phones (<=768px) the page is curated into a narrative, not shrunk. Off-arc sections (Projects, Education) are dropped, the primary CTA (Engage, then Newsletter) is pulled to the close, and every nav target still resolves. Desktop and tablet keep the full section set in source order — the mobile recomposition is a display:none plus flex-order overlay, never a separate information architecture or a content fork.",
         "section": "overview"
+      },
+      {
+        "name": "The Guided-Traversal Rule",
+        "body": "The page is one narrative, not a directory. Section headings are first-person voice-led sentences, never resume labels; most sections open with a single section-lead that advances the story; the ~/ mono kicker continues the hero console session as the connective spine. If a heading could be swapped onto any other portfolio unchanged, rewrite it.",
+        "section": "overview"
+      },
+      {
+        "name": "The No-Emoji-Icons Rule",
+        "body": "Emoji are forbidden as card icons, section markers, or heading decoration. They read as generic template furniture and break the instrument-grade voice. Identity comes from the issuer bar, the deploy-panel window bar, signal nodes, the gradient spine, and mono telemetry. The only glyph exception is the functional pipeline check inside the hero/about console panels, which is machine status, not decoration.",
+        "section": "components"
       }
     ],
     "dos": [
@@ -283,7 +295,9 @@
       "Do bump body text from Muted Slate toward Bright Ink wherever it must clear 4.5:1; Faint Slate is for large or non-critical text only.",
       "Do provide a prefers-reduced-motion fallback for every orb drift, fade-in, blink, and hover transform.",
       "Do treat the dark theme as default and keep the light theme at full parity.",
-      "Do curate mobile into a story rather than shrinking the desktop stack: on phones (<=768px) drop off-arc sections (Projects, Education) and pull the Engage to Newsletter CTA to the close so the scroll ends on the ask (The Mobile-Story Rule). Keep desktop's full section set and source order untouched — the recomposition is a media-query overlay, not a fork."
+      "Do curate mobile into a story rather than shrinking the desktop stack: on phones (<=768px) drop off-arc sections (Projects, Education) and pull the Engage to Newsletter CTA to the close so the scroll ends on the ask (The Mobile-Story Rule). Keep desktop's full section set and source order untouched — the recomposition is a media-query overlay, not a fork.",
+      "Do write section headings as first-person, voice-led sentences and open most sections with one section-lead connector, so the page reads as a guided traversal rather than a directory (The Guided-Traversal Rule).",
+      "Do give cards their identity from structure (issuer bars, the deploy-panel window bar, signal nodes, the gradient spine, mono telemetry), not from a pictorial icon (The No-Emoji-Icons Rule)."
     ],
     "donts": [
       "Don't revive the dormant Azure-blue + Segoe UI + GitHub-dark token layer as the visible brand — it's migration drift and reads as the corporate/sterile Fluent-default look the brand rejects.",
@@ -293,7 +307,10 @@
       "Don't add hard drop shadows or borders heavier than 1px to convey elevation.",
       "Don't introduce a serif or a second sans for headings, or use monospace for sentence-length copy.",
       "Don't exceed the ~96px display ceiling or tighten display letter-spacing past -0.04em.",
-      "Don't treat mobile as desktop-scaled-down: never leave a nav link pointing at a section hidden on that breakpoint, and never bury the primary CTA mid-scroll on phones. If a section is off the mobile arc, drop it and its nav entry together."
+      "Don't treat mobile as desktop-scaled-down: never leave a nav link pointing at a section hidden on that breakpoint, and never bury the primary CTA mid-scroll on phones. If a section is off the mobile arc, drop it and its nav entry together.",
+      "Don't use resume-label section titles (Professional Experience, Featured Certifications, Academic Background, Honors and Awards); write them in this person's voice instead.",
+      "Don't put emoji or pictorial icons on cards, section markers, or headings; use structural identity instead (The No-Emoji-Icons Rule).",
+      "Don't dress the stats bar as the SaaS hero-metric strip; keep the gradient numbers but label them with lowercase mono telemetry so it reads as an instrument status line."
     ]
   }
 }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -102,11 +102,15 @@ This portfolio renders a cloud architect's craft as the thing a cloud architect 
 
 The personality is **bold, precise, distinctive** — an engineer's confidence expressed as visual conviction. Density is generous and rhythmic rather than cramped: 100px section breathing, deliberate fades on scroll, restraint in the type and looseness in the dark canvas. Color is committed, not hedged: the indigo/cyan/violet triad does real work across heroes, gradients, and hover glow rather than sitting in the margins as a timid accent. Light carries depth; lines are kept hairline-faint so the glow reads.
 
-This system explicitly rejects three things, carried straight from the brand's anti-references. It is **not a generic resume template** — no interchangeable CV-builder shell where only the name changes. It is **not corporate or sterile** — no enterprise-stock, Fluent-default Microsoft look (notably, the dormant Azure-blue + Segoe UI token layer in the CSS is *drift to retire*, not the brand). And it is **not a trendy AI-startup clone** — no cream-and-slate neutrals, no gradient-mesh-by-default, no tiny tracked uppercase eyebrow stamped above every section.
+This system explicitly rejects three things, carried straight from the brand's anti-references. It is **not a generic resume template** — no interchangeable CV-builder shell where only the name changes, and no resume-label section headings ("Professional Experience", "Featured Certifications", "Academic Background"). It is **not corporate or sterile** — no enterprise-stock, Fluent-default Microsoft look (notably, the dormant Azure-blue + Segoe UI token layer in the CSS is *drift to retire*, not the brand). And it is **not a trendy AI-startup clone** — no cream-and-slate neutrals, no gradient-mesh-by-default, no tiny tracked uppercase eyebrow stamped above every section, and **no emoji icons** as card decoration (☁️/🏆/🎓 and the like read as generic template furniture, the opposite of instrument-grade).
+
+The page reads as a **story, not a directory**. Sections are narrative beats told in the architect's own first-person voice, not categories on a CV. Each section title is a sentence with a point ("From data engineer to cloud architect", "Proof, not just a profile", "Systems I've shipped"), and most content sections open with a single `section-lead` line that advances the arc rather than restating the heading. The connective spine is the `~/` mono kicker: read top to bottom, the kickers (`~/about → ~/stack → ~/experience → ~/credentials → ~/projects → ~/engage`) continue the terminal session the hero console opens, so the visitor is touring one coherent control plane rather than paging through a stack of resume blocks.
 
 Responsive behavior is composition, not just reflow. The desktop surface runs the full eleven-section sequence; the phone surface is **curated to a tighter story** because a mobile visit is short and one-handed (PRODUCT.md: *"short, evaluative visits, often arriving from LinkedIn… frequently on mobile"*). The mobile arc reads: identity (hero) → proof (stats) → how I work (the pinned About story) → the stack → track record (experience) → credentials (certs) → recognition (awards) → **the ask (Engage)** → **stay in touch (Newsletter)**. Two desktop sections, Projects and Education, are tangents to that arc and are dropped on phones (their full content still lives on dedicated pages and on desktop/tablet); the Engage → Newsletter call-to-action is pulled to the end so the scroll lands on the ask, not on a list of awards.
 
 **The Mobile-Story Rule.** On phones (`≤768px`) the page is curated into a narrative, not shrunk. Off-arc sections are dropped, the primary CTA (Engage, then Newsletter) is pulled to the close, and every nav target still resolves. Desktop and tablet keep the full section set in source order — the mobile recomposition is a `display:none` + flex-`order` overlay, never a separate information architecture or a content fork.
+
+**The Guided-Traversal Rule.** The page is one narrative, not a directory of sections. Every section heading is a voice-led sentence in the first person ("From data engineer to cloud architect", "Proof, not just a profile", "Systems I've shipped"), never a resume label ("Professional Experience", "Featured Certifications"). Most content sections open with a single `section-lead` line that advances the story instead of restating the title, and the `~/` mono kicker continues the hero console's terminal session as the connective spine. If a heading could be swapped onto any other portfolio unchanged, rewrite it until it carries this person's voice.
 
 **Key Characteristics:**
 - Dark by default (near-black deep-space canvas); a full light theme exists as an opt-in override.
@@ -114,6 +118,8 @@ Responsive behavior is composition, not just reflow. The desktop surface runs th
 - Monospace (JetBrains Mono) reserved for telemetry: dates, eyebrows, metadata, the logo, the cursor.
 - Depth via blur, glow, and translucency — never via heavy drop shadows or borders.
 - Glow-on-hover and small directional nudges (`translateX`/`translateY`) as the interaction signature.
+- A story read top to bottom: voice-led section titles, a `section-lead` connector per section, and the `~/` kicker carrying one terminal session through the page (The Guided-Traversal Rule).
+- No emoji and no pictorial card icons: identity comes from structure — issuer bars, gradient signal-nodes, the deploy-panel window bar, and mono telemetry.
 - Mobile is a curated story, not a scaled-down desktop: tangential sections drop away and the Engage → Newsletter CTA closes the scroll (The Mobile-Story Rule).
 
 ## 2. Colors
@@ -155,7 +161,8 @@ A committed dark palette where a single indigo→cyan gradient carries the brand
 - **Headline** (800, `clamp(2rem, 4vw, 2.75rem)`, lh 1.15, ls -0.02em): Section and page titles.
 - **Title** (700, 1.05rem, lh 1.3): Card titles — roles, cert names, project names, award titles.
 - **Body** (400, 1–1.05rem, lh 1.6–1.75): Paragraph copy and descriptions. Constrain to ~520–560px (≈65–75ch) for hero and about text.
-- **Label** (600, 0.75rem, ls 0.05–0.12em, UPPERCASE, JetBrains Mono): Eyebrows, dates, metadata pills, stat labels, the scroll indicator. Always monospace, always short.
+- **Label** (600, 0.75rem, ls 0.05–0.12em, UPPERCASE, JetBrains Mono): Eyebrows, dates, metadata pills, the scroll indicator. Always monospace, always short.
+- **Telemetry caption** (500, 0.78rem, JetBrains Mono, **lowercase**): Stat-bar labels ("years building", "projects shipped") and similar readouts. Mono and lowercase so the stats bar reads as an instrument status line, not the uppercase-tracked SaaS metric strip.
 
 ### Named Rules
 **The Mono-Is-Instrumentation Rule.** JetBrains Mono is reserved for telemetry-class text: dates, code-ish labels, the `<AR/>` logo, the cursor, section tags. It is forbidden for headings, body copy, or anything sentence-length. Mono here earns its keep because the subject *is* technical; it is never decoration.
@@ -217,6 +224,18 @@ Three offer cards (Cloud architecture, Team training, Speaking) in a `repeat(3, 
 ### Signature: The Experience Timeline
 A two-column grid (40px marker rail + content) where each entry is a glowing indigo **node** (`14px`, Node Glow halo) connected by a gradient line that fades to transparent. Cards carry a square company badge with a per-company gradient, a monospace date pill, and `›`-marked bullets in indigo. This is the system's most distinctive pattern — the literal "control plane" read — and should be preserved as the model for any chronological content.
 
+### Card identity without icons
+Cards earn their identity from structure, never from a decorative icon. **Cert cards** lead with the colored issuer bar (`azure` / `hashicorp` / `github` …) plus the cert name and a cyan mono date — no emoji. **Project cards** in the gallery rail wear a deploy-panel window bar (three traffic-light dots) as their visual anchor; the project name leads directly under it. Removing the old emoji slot is the rule, not a one-off: a pictorial icon above a card heading is the template tell this system rejects.
+
+### Signal nodes
+Awards and homepage education entries are marked by a small **signal node** (`.award-node` / `.edu-node`: a 12px gradient dot with a soft indigo glow), reusing the timeline/signal vocabulary so achievements read as live markers on the control plane rather than trophy/graduation emoji. In a centered row the node sits inline; in the awards-full grid (`auto 1fr auto`) it holds the first column with a `7px` top nudge onto the title's first line.
+
+### Narrative lead
+`section-lead` is the story's connective tissue: one centered line under a section title (`max-width: 44rem`, Muted Slate, `text-wrap: pretty`) that advances the arc rather than restating the heading. Used on most content sections, never as a generic subtitle.
+
+### Named Rules
+**The No-Emoji-Icons Rule.** Emoji are forbidden as card icons, section markers, or heading decoration (☁️/🏆/🎓/🐳 and the family). They read as generic template furniture and break the instrument-grade voice. Identity comes from the issuer bar, the window bar, signal nodes, the gradient spine, and mono telemetry. The only glyph exception is the functional pipeline `✓` inside the hero/about console panels, which is machine status, not decoration.
+
 ## 6. Do's and Don'ts
 
 ### Do:
@@ -228,10 +247,14 @@ A two-column grid (40px marker rail + content) where each entry is a glowing ind
 - **Do** provide a `prefers-reduced-motion` fallback (crossfade or instant) for every orb drift, fade-in, blink, and hover transform — the bold motion makes this non-negotiable.
 - **Do** treat the dark theme as default and keep the light theme at full parity (it already exists as a `[data-theme="light"]` override).
 - **Do** curate mobile into a story rather than shrinking the desktop stack: on phones (`≤768px`) drop off-arc sections (Projects, Education) and pull the Engage → Newsletter CTA to the close so the scroll ends on the ask (The Mobile-Story Rule). Keep desktop's full section set and source order untouched — the recomposition is a media-query overlay, not a fork.
+- **Do** write section headings as first-person, voice-led sentences and open most sections with one `section-lead` connector, so the page reads as a guided traversal rather than a directory (The Guided-Traversal Rule).
+- **Do** give cards their identity from structure — issuer bars, the deploy-panel window bar, signal nodes, the gradient spine, mono telemetry — not from a pictorial icon (The No-Emoji-Icons Rule).
 
 ### Don't:
 - **Don't** revive the dormant Azure-blue (`#0078D4`) + Segoe UI + GitHub-dark token layer as the visible brand — it's migration drift and it reads as the **corporate / sterile, Fluent-default Microsoft look** the brand explicitly rejects.
-- **Don't** let the page slide into a **generic resume template** — if a section could belong to any portfolio with the name swapped, give it the control-plane treatment (glow, mono telemetry, gradient spine) instead.
+- **Don't** let the page slide into a **generic resume template** — if a section could belong to any portfolio with the name swapped, give it the control-plane treatment (glow, mono telemetry, gradient spine) instead. This includes the headings: no resume-label titles ("Professional Experience", "Featured Certifications", "Academic Background", "Honors & Awards").
+- **Don't** put emoji or pictorial icons on cards, section markers, or headings (☁️/🏆/🎓/🐳 …). They read as the generic-template look the brand rejects; use structural identity instead (The No-Emoji-Icons Rule). The functional pipeline `✓` in the console panels is the only allowed glyph.
+- **Don't** dress the stats bar as the SaaS hero-metric strip (big gradient number + tiny tracked-uppercase label). Keep the gradient numbers (brand) but label them with lowercase mono telemetry so it reads as an instrument status line.
 - **Don't** drift toward a **trendy AI-startup clone**: no cream-and-slate neutrals, no gradient-mesh-by-default hero, and no tiny tracked-uppercase eyebrow stamped above *every* section. One mono `section-tag` used with intent is voice; on every heading it's AI scaffolding.
 - **Don't** use cyan as a large fill or as body text (The Cyan-Is-Telemetry Rule), and never invert or re-angle the gradient spine.
 - **Don't** add hard drop shadows or borders heavier than 1px to convey elevation; that's the 2014-app tell this system is built to avoid.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -170,7 +170,7 @@
         </div>
       </div>
       <div class="footer-newsletter">
-        <p>Think you know DevOps? Subscribe to my LinkedIn newsletter for insights on Cloud, DevOps &amp; Architecture.</p>
+        <p>A weekly LinkedIn newsletter on cloud architecture, CI/CD, and the Azure work I'm doing now.</p>
         <a href="https://www.linkedin.com/newsletters/7440660160471281665/" target="_blank" rel="noopener" class="btn btn-outline">Subscribe to Newsletter →</a>
         <a href="https://blog.abubakarriaz.com.pk/rss.xml" target="_blank" rel="noopener" class="footer-rss-link" aria-label="RSS Feed">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20C4.98 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/></svg>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -379,6 +379,8 @@
   transform: translateX(6px);
 }
 .award-full-icon { font-size: 2.5rem; }
+/* Awards-full grid keeps its first column; the node aligns to the title's first line. */
+.award-full-item .award-node { margin-top: 7px; }
 .award-full-title {
   margin: 0;
   font-size: 1.05rem;
@@ -1025,11 +1027,11 @@ img { max-width: 100%; display: block; }
 }
 
 .stat-label {
-  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
   font-weight: 500;
   color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.01em;
 }
 
 .stat-divider {
@@ -1617,6 +1619,14 @@ img { max-width: 100%; display: block; }
 }
 
 .edu-icon { font-size: 2.5rem; flex-shrink: 0; }
+/* A telemetry node anchors each entry instead of a graduation-cap emoji. */
+.edu-node {
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--gradient);
+  box-shadow: 0 0 14px rgba(99, 102, 241, 0.55);
+  flex-shrink: 0;
+  margin-top: 7px;
+}
 .edu-period {
   display: block;
   font-family: var(--font-mono);
@@ -1669,6 +1679,13 @@ img { max-width: 100%; display: block; }
 }
 
 .award-icon { font-size: 1.75rem; flex-shrink: 0; }
+/* Awards read as signals on the control plane: a glowing node, not a trophy emoji. */
+.award-node {
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--gradient);
+  box-shadow: 0 0 14px rgba(99, 102, 241, 0.55);
+  flex-shrink: 0;
+}
 .award-body { flex: 1; min-width: 0; }
 .award-title {
   font-size: 0.975rem;

--- a/awards/index.html
+++ b/awards/index.html
@@ -30,7 +30,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
     <div class="awards-list">
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">🏅</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">The Promotion Award</h2>
           <p class="award-full-issuer">Issued by Tkxel People Team · Tkxel LLC</p>
@@ -41,7 +41,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
       </div>
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">🛡️</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">OWASP AI Security Award</h2>
           <p class="award-full-issuer">Issued by OWASP Lahore Chapter</p>
@@ -52,7 +52,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
       </div>
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">🏆</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">The Dream Team Award</h2>
           <p class="award-full-issuer">Issued by Tkxel People Team · Tkxel LLC</p>
@@ -63,7 +63,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
       </div>
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">🏅</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">The Promotion Award</h2>
           <p class="award-full-issuer">Issued by Tkxel People Team · Tkxel LLC</p>
@@ -74,7 +74,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
       </div>
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">🏆</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">Quarterly Divisional Champion of Q1 2022</h2>
           <p class="award-full-issuer">Issued by Jazz People &amp; Organization · Jazz Telecom</p>
@@ -87,7 +87,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
       </div>
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">🏆</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">Top Performer 2019</h2>
           <p class="award-full-issuer">Issued by Jazz People &amp; Organization · Jazz Telecom</p>
@@ -100,7 +100,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
       </div>
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">🌟</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">On Spot Recognition</h2>
           <p class="award-full-issuer">Issued by Jazz Director, Customer Relationship Management · Jazz Telecom</p>
@@ -113,7 +113,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
       </div>
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">🌟</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">Quality Effective Behavior</h2>
           <p class="award-full-issuer">Issued by Mobilink Vice President Customer Care</p>
@@ -126,7 +126,7 @@ description: "Recognition and honors earned by Abubakar Riaz throughout his care
       </div>
 
       <div class="award-full-item animate-on-scroll">
-        <div class="award-full-icon">⭐</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h2 class="award-full-title">Quality Work</h2>
           <p class="award-full-issuer">Issued by Mobilink Vice President Customer Care</p>

--- a/certifications/index.html
+++ b/certifications/index.html
@@ -35,13 +35,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- Azure Cloud Engineer -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">☁️ Azure Cloud Engineer</h2>
+      <h2 class="cert-category-title">Azure Cloud Engineer</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">☁️</div>
           <h3 class="cert-name">Azure Solutions Architect Expert (AZ-305)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Mar 2025</span>
@@ -50,7 +49,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🏆</div>
           <h3 class="cert-name">Microsoft Certified Trainer (MCT 2026)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Mar 2025</span>
@@ -59,7 +57,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🔐</div>
           <h3 class="cert-name">Security, Compliance &amp; Identity Fundamentals (SC-900)</h3>
           <span class="cert-issuer-label">Microsoft</span>
         </div>
@@ -67,7 +64,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">☁️</div>
           <h3 class="cert-name">Azure Developer Associate (AZ-204)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Mar 2024</span>
@@ -77,7 +73,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">☁️</div>
           <h3 class="cert-name">Azure Administrator Associate (AZ-104)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Jun 2023</span>
@@ -95,7 +90,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">☁️</div>
           <h3 class="cert-name">Azure Fundamentals (AZ-900)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Aug 2022</span>
@@ -111,7 +105,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🗄️</div>
           <h3 class="cert-name">Microsoft Azure SQL</h3>
           <span class="cert-issuer-label">Microsoft – Coursera</span>
           <span class="cert-date">Aug 2022</span>
@@ -122,13 +115,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- DevOps Engineer -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">⚙️ DevOps Engineer</h2>
+      <h2 class="cert-category-title">DevOps Engineer</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">⚙️</div>
           <h3 class="cert-name">DevOps Engineer Expert (AZ-400)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Mar 2025</span>
@@ -137,7 +129,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar hashicorp"></div>
         <div class="cert-body">
-          <div class="cert-icon">🔧</div>
           <h3 class="cert-name">Terraform Associate (003)</h3>
           <span class="cert-issuer-label">HashiCorp</span>
           <span class="cert-date">Mar 2024</span>
@@ -147,7 +138,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">🐙</div>
           <h3 class="cert-name">GitHub Actions</h3>
           <span class="cert-issuer-label">GitHub</span>
           <span class="cert-date">Feb 2024</span>
@@ -157,7 +147,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">🐙</div>
           <h3 class="cert-name">GitHub Foundations</h3>
           <span class="cert-issuer-label">GitHub</span>
           <span class="cert-date">Feb 2024</span>
@@ -167,7 +156,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🔁</div>
           <h3 class="cert-name">Continuous Delivery with Azure DevOps</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">Aug 2020</span>
@@ -177,7 +165,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🐧</div>
           <h3 class="cert-name">Linux: Introduction to Shell Scripting for DevOps</h3>
           <span class="cert-issuer-label">Coursera</span>
           <span class="cert-date">Nov 2022</span>
@@ -187,7 +174,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">🤖</div>
           <h3 class="cert-name">Ansible Essential Training</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">Dec 2022</span>
@@ -198,13 +184,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- Docker Expert -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">🐳 Docker Expert</h2>
+      <h2 class="cert-category-title">Docker Expert</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">🐳</div>
           <h3 class="cert-name">Learning Docker</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">Oct 2022</span>
@@ -214,7 +199,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🐳</div>
           <h3 class="cert-name">Docker for Absolute Beginners</h3>
           <span class="cert-issuer-label">Coursera</span>
           <span class="cert-date">Oct 2022</span>
@@ -225,13 +209,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- Software Architect -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">🏗️ Software Architect</h2>
+      <h2 class="cert-category-title">Software Architect</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🏗️</div>
           <h3 class="cert-name">Software Design &amp; Architecture Specialization</h3>
           <span class="cert-issuer-label">University of Alberta – Coursera</span>
           <span class="cert-date">Oct 2022</span>
@@ -248,13 +231,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- ASP.NET Core Developer -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">💻 ASP.NET Core Developer</h2>
+      <h2 class="cert-category-title">ASP.NET Core Developer</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar freecodecamp"></div>
         <div class="cert-body">
-          <div class="cert-icon">🟣</div>
           <h3 class="cert-name">Foundational C# with Microsoft</h3>
           <span class="cert-issuer-label">freeCodeCamp</span>
           <span class="cert-date">Apr 2024</span>
@@ -264,7 +246,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🚀</div>
           <h3 class="cert-name">Deploying ASP.NET Core Applications</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">Oct 2019</span>
@@ -274,7 +255,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">💻</div>
           <h3 class="cert-name">Learning ASP.NET Core MVC</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">May 2019</span>
@@ -285,13 +265,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- Python Developer -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">🐍 Python Developer</h2>
+      <h2 class="cert-category-title">Python Developer</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🐍</div>
           <h3 class="cert-name">Python for Everybody Specialization</h3>
           <span class="cert-issuer-label">University of Michigan – Coursera</span>
           <span class="cert-date">Feb 2022</span>
@@ -308,13 +287,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- SQL Server Developer -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">🗄️ SQL Server Developer</h2>
+      <h2 class="cert-category-title">SQL Server Developer</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🗄️</div>
           <h3 class="cert-name">Certified SQL Server Specialist</h3>
           <span class="cert-issuer-label">EVS Professional Training Institute</span>
           <span class="cert-date">Sep 2013</span>
@@ -324,7 +302,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🗄️</div>
           <h3 class="cert-name">PostgreSQL for Everybody</h3>
           <span class="cert-issuer-label">University of Michigan – Coursera</span>
           <span class="cert-date">Sep 2022</span>
@@ -335,13 +312,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- API Developer -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">🔌 API Developer</h2>
+      <h2 class="cert-category-title">API Developer</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🔌</div>
           <h3 class="cert-name">Become a RESTful API Developer</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">Oct 2019</span>
@@ -358,13 +334,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- Agile Project Manager -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">📋 Agile Project Manager</h2>
+      <h2 class="cert-category-title">Agile Project Manager</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">📋</div>
           <h3 class="cert-name">Programme on Project Management</h3>
           <span class="cert-issuer-label">LUMS – Lahore University of Management Sciences</span>
           <span class="cert-date">Jan 2020</span>
@@ -374,7 +349,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">🔄</div>
           <h3 class="cert-name">Agile Foundations</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">Aug 2019</span>
@@ -384,7 +358,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">📋</div>
           <h3 class="cert-name">Mastering your Projects — The PMBOK Way</h3>
           <span class="cert-issuer-label">Jazz Telecom</span>
           <span class="cert-date">Aug 2013</span>
@@ -395,13 +368,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- .NET Developer -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">🟣 .NET Developer</h2>
+      <h2 class="cert-category-title">.NET Developer</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🟣</div>
           <h3 class="cert-name">Certified .Net Specialist</h3>
           <span class="cert-issuer-label">EVS Professional Training Institute</span>
           <span class="cert-date">Apr 2014</span>
@@ -411,7 +383,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">🟣</div>
           <h3 class="cert-name">Introduction to Blazor</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">Dec 2021</span>
@@ -422,13 +393,12 @@ og_image: /assets/images/og-certifications.png
 
     <!-- Other -->
     <div class="cert-category animate-on-scroll">
-      <h2 class="cert-category-title">🌐 Go · PowerShell · SEO · Networking</h2>
+      <h2 class="cert-category-title">Go · PowerShell · SEO · Networking</h2>
     </div>
     <div class="cert-grid animate-on-scroll">
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🐹</div>
           <h3 class="cert-name">Getting Started with Go</h3>
           <span class="cert-issuer-label">University of California, Irvine – Coursera</span>
           <span class="cert-date">Jul 2022</span>
@@ -438,7 +408,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">⚡</div>
           <h3 class="cert-name">Learning PowerShell</h3>
           <span class="cert-issuer-label">LinkedIn Learning</span>
           <span class="cert-date">Jun 2020</span>
@@ -448,7 +417,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🔍</div>
           <h3 class="cert-name">Training on Search Engine Optimization</h3>
           <span class="cert-issuer-label">ITHeight, Lahore</span>
           <span class="cert-date">Dec 2017</span>
@@ -458,7 +426,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">🌐</div>
           <h3 class="cert-name">Cisco Certified Network Associate (CCNA)</h3>
           <span class="cert-issuer-label">Corvit Networks, Lahore</span>
           <span class="cert-date">Mar 2012</span>
@@ -467,7 +434,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🎨</div>
           <h3 class="cert-name">Graphic Designing</h3>
           <span class="cert-issuer-label">Peak Solutions College, Lahore</span>
           <span class="cert-date">Aug 2012</span>
@@ -477,7 +443,6 @@ og_image: /assets/images/og-certifications.png
       <div class="cert-card">
         <div class="cert-issuer-bar coursera"></div>
         <div class="cert-body">
-          <div class="cert-icon">🌐</div>
           <h3 class="cert-name">PHP Web Development</h3>
           <span class="cert-issuer-label">Peak Solutions College, Lahore</span>
           <span class="cert-date">Nov 2011</span>

--- a/education/index.html
+++ b/education/index.html
@@ -35,7 +35,6 @@ description: "Academic background of Abubakar Riaz — BS Computer Science from 
           <div class="timeline-line"></div>
         </div>
         <div class="edu-full-card">
-          <div class="edu-full-icon">🎓</div>
           <div class="edu-body">
             <span class="edu-period">2015 – 2024</span>
             <h2 class="edu-degree">Master's in Computer Science (MCS)</h2>
@@ -51,7 +50,6 @@ description: "Academic background of Abubakar Riaz — BS Computer Science from 
           <div class="timeline-line"></div>
         </div>
         <div class="edu-full-card">
-          <div class="edu-full-icon">🎓</div>
           <div class="edu-body">
             <span class="edu-period">2006 – 2010</span>
             <h2 class="edu-degree">Master's in Commerce (B.COM Honors)</h2>
@@ -68,7 +66,6 @@ description: "Academic background of Abubakar Riaz — BS Computer Science from 
           <div class="timeline-line"></div>
         </div>
         <div class="edu-full-card">
-          <div class="edu-full-icon">📚</div>
           <div class="edu-body">
             <span class="edu-period">2004 – 2006</span>
             <h2 class="edu-degree">Intermediate (FSc / ICS)</h2>
@@ -84,7 +81,6 @@ description: "Academic background of Abubakar Riaz — BS Computer Science from 
           <div class="timeline-dot"></div>
         </div>
         <div class="edu-full-card">
-          <div class="edu-full-icon">🏫</div>
           <div class="edu-body">
             <span class="edu-period">2002 – 2004</span>
             <h2 class="edu-degree">Matriculation (SSC)</h2>

--- a/index.html
+++ b/index.html
@@ -108,22 +108,22 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
   <div class="stats-grid container">
     <div class="stat-item">
       <span class="stat-number"><span class="stat-value" data-count="15">15</span><span class="stat-plus">+</span></span>
-      <span class="stat-label">Years Experience</span>
+      <span class="stat-label">years building</span>
     </div>
     <div class="stat-divider"></div>
     <div class="stat-item">
       <span class="stat-number"><span class="stat-value" data-count="25">25</span><span class="stat-plus">+</span></span>
-      <span class="stat-label">Certifications</span>
+      <span class="stat-label">certifications</span>
     </div>
     <div class="stat-divider"></div>
     <div class="stat-item">
       <span class="stat-number"><span class="stat-value" data-count="40">40</span><span class="stat-plus">+</span></span>
-      <span class="stat-label">Major Projects</span>
+      <span class="stat-label">projects shipped</span>
     </div>
     <div class="stat-divider"></div>
     <div class="stat-item">
       <span class="stat-number"><span class="stat-value" data-count="8">8</span></span>
-      <span class="stat-label">Companies</span>
+      <span class="stat-label">organizations</span>
     </div>
   </div>
 </div>
@@ -241,8 +241,9 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
 <section class="section" id="capabilities">
   <div class="container">
     <div class="section-header animate-on-scroll">
-      <span class="section-tag">capabilities</span>
-      <h2 class="section-title">The <span class="gradient-text">stack</span> I operate</h2>
+      <span class="section-tag">stack</span>
+      <h2 class="section-title">The layer I <span class="gradient-text">operate</span></h2>
+      <p class="section-lead">Every system I touch runs on the same disciplined foundation. This is what sits under it.</p>
     </div>
     <div class="bento">
 
@@ -317,7 +318,8 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
   <div class="container">
     <div class="section-header animate-on-scroll">
       <span class="section-tag">experience</span>
-      <h2 class="section-title">Professional <span class="gradient-text">Experience</span></h2>
+      <h2 class="section-title">From data engineer to <span class="gradient-text">cloud architect</span></h2>
+      <p class="section-lead">One instinct, automate the manual work, runs through every role. The titles changed; the depth compounded.</p>
     </div>
     <div class="timeline">
 
@@ -418,8 +420,9 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
 <section class="section" id="certifications">
   <div class="container">
     <div class="section-header animate-on-scroll">
-      <span class="section-tag">certifications</span>
-      <h2 class="section-title">Featured <span class="gradient-text">Certifications</span></h2>
+      <span class="section-tag">credentials</span>
+      <h2 class="section-title">Proof, not just a <span class="gradient-text">profile</span></h2>
+      <p class="section-lead">Twenty-five-plus certifications across Azure, DevOps, and HashiCorp. These are the ones I reach for most.</p>
     </div>
     <div class="h-rail animate-on-scroll">
       <button type="button" class="rail-btn rail-prev" aria-label="Scroll certifications left" data-rail="certRail">
@@ -430,7 +433,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       <div class="cert-card">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">☁️</div>
           <h3 class="cert-name">Azure Solutions Architect Expert (AZ-305)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Mar 2025</span>
@@ -440,7 +442,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       <div class="cert-card animate-on-scroll">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">⚙️</div>
           <h3 class="cert-name">DevOps Engineer Expert (AZ-400)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Mar 2025</span>
@@ -450,7 +451,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       <div class="cert-card animate-on-scroll">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">🏆</div>
           <h3 class="cert-name">Microsoft Certified Trainer (MCT 2026)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Mar 2025</span>
@@ -460,7 +460,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       <div class="cert-card animate-on-scroll">
         <div class="cert-issuer-bar azure"></div>
         <div class="cert-body">
-          <div class="cert-icon">☁️</div>
           <h3 class="cert-name">Azure Developer Associate (AZ-204)</h3>
           <span class="cert-issuer-label">Microsoft</span>
           <span class="cert-date">Mar 2024</span>
@@ -471,7 +470,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       <div class="cert-card animate-on-scroll">
         <div class="cert-issuer-bar hashicorp"></div>
         <div class="cert-body">
-          <div class="cert-icon">🔧</div>
           <h3 class="cert-name">Terraform Associate (003)</h3>
           <span class="cert-issuer-label">HashiCorp</span>
           <span class="cert-date">Mar 2024</span>
@@ -482,7 +480,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       <div class="cert-card animate-on-scroll">
         <div class="cert-issuer-bar github"></div>
         <div class="cert-body">
-          <div class="cert-icon">🐙</div>
           <h3 class="cert-name">GitHub Actions</h3>
           <span class="cert-issuer-label">GitHub</span>
           <span class="cert-date">Feb 2024</span>
@@ -508,7 +505,8 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
   <div class="container">
     <div class="section-header animate-on-scroll">
       <span class="section-tag">projects</span>
-      <h2 class="section-title">Notable <span class="gradient-text">Projects</span></h2>
+      <h2 class="section-title">Systems I've <span class="gradient-text">shipped</span></h2>
+      <p class="section-lead">Telecom-scale services, APIs, and data pipelines, built to stay boring in production.</p>
     </div>
     <div class="h-rail h-rail--lg animate-on-scroll">
       <button type="button" class="rail-btn rail-prev" aria-label="Scroll projects left" data-rail="projRail">
@@ -517,9 +515,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       <div class="rail-track" id="projRail" tabindex="0" role="region" aria-label="Notable projects, scrollable" data-lenis-prevent>
 
       <div class="project-card">
-        <div class="project-header">
-          <div class="project-icon">🎤</div>
-        </div>
         <h3 class="project-name">Backend Voice of Customer</h3>
         <p class="project-desc">Backend web application for capturing and processing customer feedback in a telecom environment.</p>
         <div class="project-tags">
@@ -530,9 +525,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="project-card animate-on-scroll">
-        <div class="project-header">
-          <div class="project-icon">🔄</div>
-        </div>
         <h3 class="project-name">Restoration on Commitment API</h3>
         <p class="project-desc">RESTful API service for automated customer service restoration based on commitment workflows.</p>
         <div class="project-tags">
@@ -543,9 +535,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="project-card animate-on-scroll">
-        <div class="project-header">
-          <div class="project-icon">🏠</div>
-        </div>
         <h3 class="project-name">Service Home Delivery Web App</h3>
         <p class="project-desc">Full-stack web application for managing telecom service home delivery requests and scheduling.</p>
         <div class="project-tags">
@@ -556,9 +545,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="project-card animate-on-scroll">
-        <div class="project-header">
-          <div class="project-icon">📊</div>
-        </div>
         <h3 class="project-name">Digital Business Solution ETL</h3>
         <p class="project-desc">Enterprise ETL pipeline for digital business solutions using SSIS packages with automated scheduling.</p>
         <div class="project-tags">
@@ -569,9 +555,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="project-card animate-on-scroll">
-        <div class="project-header">
-          <div class="project-icon">📋</div>
-        </div>
         <h3 class="project-name">Blocking &amp; Restoration via CSV</h3>
         <p class="project-desc">Console application for bulk telecom service management through CSV-driven automation workflows.</p>
         <div class="project-tags">
@@ -582,9 +565,6 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="project-card animate-on-scroll">
-        <div class="project-header">
-          <div class="project-icon">💳</div>
-        </div>
         <h3 class="project-name">Credit Monitoring Web App</h3>
         <p class="project-desc">Internal MVC application for real-time credit rating monitoring and enforcement of telecom services.</p>
         <div class="project-tags">
@@ -669,10 +649,10 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
     <div class="newsletter-banner-content animate-on-scroll">
       <div class="newsletter-banner-text">
         <span class="section-tag">newsletter</span>
-        <h2 class="newsletter-banner-title">Think you know <span class="gradient-text">DevOps?</span></h2>
+        <h2 class="newsletter-banner-title">What I'm learning, <span class="gradient-text">written down</span></h2>
         <p class="newsletter-banner-desc">
-          Subscribe to my LinkedIn newsletter for insights on cloud architecture,
-          CI/CD pipelines, Azure, and modern DevOps practices, straight to your inbox.
+          A weekly LinkedIn newsletter on cloud architecture, CI/CD, and the Azure
+          work I'm doing right now. The notes I wish I'd had earlier in my career.
         </p>
       </div>
       <div class="newsletter-banner-action">
@@ -689,12 +669,13 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
   <div class="container">
     <div class="section-header animate-on-scroll">
       <span class="section-tag">education</span>
-      <h2 class="section-title">Academic <span class="gradient-text">Background</span></h2>
+      <h2 class="section-title">Where the <span class="gradient-text">foundation</span> was laid</h2>
+      <p class="section-lead">A computer-science master's on top of a commerce degree, finance taught me to read systems before I built them.</p>
     </div>
     <div class="education-grid">
 
       <div class="edu-card animate-on-scroll">
-        <div class="edu-icon">🎓</div>
+        <span class="edu-node" aria-hidden="true"></span>
         <div class="edu-body">
           <span class="edu-period">2015 – 2024</span>
           <h3 class="edu-degree">Master's in Computer Science (MCS)</h3>
@@ -704,7 +685,7 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="edu-card animate-on-scroll">
-        <div class="edu-icon">🎓</div>
+        <span class="edu-node" aria-hidden="true"></span>
         <div class="edu-body">
           <span class="edu-period">2006 – 2010</span>
           <h3 class="edu-degree">Master's in Commerce (B.COM Honors)</h3>
@@ -727,12 +708,13 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
   <div class="container">
     <div class="section-header animate-on-scroll">
       <span class="section-tag">awards</span>
-      <h2 class="section-title">Honors &amp; <span class="gradient-text">Awards</span></h2>
+      <h2 class="section-title">Recognition <span class="gradient-text">along the way</span></h2>
+      <p class="section-lead">Markers from the teams I've worked with, for security, delivery, and the people around the work.</p>
     </div>
     <div class="awards-list">
 
       <div class="award-item animate-on-scroll">
-        <div class="award-icon">🛡️</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h3 class="award-title">OWASP AI Security Award</h3>
           <span class="award-issuer">OWASP Lahore</span>
@@ -741,7 +723,7 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="award-item animate-on-scroll">
-        <div class="award-icon">🏅</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h3 class="award-title">The Promotion Award</h3>
           <span class="award-issuer">Tkxel People Team</span>
@@ -750,7 +732,7 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="award-item animate-on-scroll">
-        <div class="award-icon">🏆</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h3 class="award-title">The Dream Team Award</h3>
           <span class="award-issuer">Tkxel People Team</span>
@@ -759,7 +741,7 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="award-item animate-on-scroll">
-        <div class="award-icon">🏆</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h3 class="award-title">Quarterly Divisional Champion Q1 2022</h3>
           <span class="award-issuer">Jazz People &amp; Organization</span>
@@ -768,7 +750,7 @@ og_image_alt: "Abubakar Riaz — Cloud Architect & DevOps Engineer portfolio pre
       </div>
 
       <div class="award-item animate-on-scroll">
-        <div class="award-icon">🏆</div>
+        <span class="award-node" aria-hidden="true"></span>
         <div class="award-body">
           <h3 class="award-title">Top Performer 2019</h3>
           <span class="award-issuer">Jazz People &amp; Organization</span>

--- a/projects/index.html
+++ b/projects/index.html
@@ -37,7 +37,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">🎤</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Backend Voice of Customer</h3>
             <span class="project-cost">Est. Vendor Cost: $40K/annum</span>
@@ -51,7 +50,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">🏆</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Call of Fame Web App</h3>
             <span class="project-cost">Est. Vendor Cost: $25K/annum</span>
@@ -65,7 +63,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">🔄</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Restoration on Commitment API</h3>
           </div>
@@ -78,7 +75,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">🏠</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Service Home Delivery Web App</h3>
             <span class="project-cost">Est. Vendor Cost: $30K/annum</span>
@@ -92,7 +88,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">📊</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Digital Business Solution Services ETL</h3>
             <span class="project-cost">Est. Vendor Cost: $100K/annum</span>
@@ -106,7 +101,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">📋</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Blocking &amp; Restoration Through CSV</h3>
           </div>
@@ -119,7 +113,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">💳</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Credit Monitoring Web App</h3>
           </div>
@@ -132,7 +125,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">📍</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">7089 Office Locator (SMS Short Code)</h3>
             <span class="project-cost">Est. Vendor Cost: $20K/annum</span>
@@ -146,7 +138,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">🔒</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Digital Fraud Complain API</h3>
           </div>
@@ -159,7 +150,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">📧</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">EmailTopia Service API</h3>
           </div>
@@ -172,7 +162,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">🗺️</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">Nearest Jazz Locator API</h3>
           </div>
@@ -185,7 +174,6 @@ og_image: /assets/images/og-projects.png
 
       <div class="project-full-card animate-on-scroll">
         <div class="project-full-header">
-          <div class="project-full-icon">📦</div>
           <div class="project-full-meta">
             <h3 class="project-full-name">FTP Common Language Runtime</h3>
           </div>


### PR DESCRIPTION
## Summary

Reframes the homepage as a **first-person guided traversal of "the control plane"** instead of a stack of resume sections, and removes the remaining AI-slop tells — while preserving the established Control Plane brand and every test invariant.

The site was already a strong dark indigo→cyan brand, so the slop wasn't the theme; it was three specific things sitting inside it.

## What changed

**Story form (the main reshape)**
- Section titles are now voice-led beats, not resume labels: *"From data engineer to cloud architect"*, *"Proof, not just a profile"*, *"Systems I've shipped"*, *"Where the foundation was laid"*, *"Recognition along the way"*.
- Each content section opens with a `section-lead` connector that advances the narrative instead of restating the heading.
- The `~/` mono kicker now reads as one continuous terminal session (`~/about → ~/stack → ~/experience → ~/credentials → ~/projects`), continuing the hero console.

**De-slop**
- Removed **all emoji icons** (~70) across the homepage and inner pages (certs, projects, education, awards). Identity now comes from structure: cert **issuer bars**, the project **deploy-panel window bar**, gradient **signal-nodes** (`.award-node` / `.edu-node`), and mono telemetry.
- Stats bar labels → lowercase **mono telemetry** ("years building", "projects shipped"); gradient numbers kept as brand.
- Rewrote gimmicky copy ("Think you know DevOps?", "straight to your inbox") on the homepage and the site-wide footer.

**Docs**
- `DESIGN.md` + `.impeccable/design.json`: added **The Guided-Traversal Rule** and **The No-Emoji-Icons Rule**, a telemetry-caption type role, the signal-node / narrative-lead components, and matching Do's/Don'ts. `PRODUCT.md` left untouched (strategy unchanged).

## How to test

- `cd tests && BASE_URL=http://localhost:4010 npx playwright test` against a local `jekyll serve`.
- Verified locally: heading hierarchy (one H1, sequential), generic-anchor (5.2.3, all pages), alt-text (5.2.1), and landmark checks **pass**. JS hooks (stat `data-count` counters, pinned About story, horizontal rails, console boot) intact.
- Visually verified dark + light at desktop and 390px mobile; mobile story-order preserved (certs → awards → engage → newsletter; Projects/Education still dropped on phones).
- Remaining local test reds are pre-existing/environmental only (GA-`load` navigation timeouts; `jekyll-seo-tag` canonical/JSON-LD/title checks comparing production `site.url` against `localhost`) — none touch the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)